### PR TITLE
'shared' protection level

### DIFF
--- a/DPPickerManager/Class/DPPickerManager.swift
+++ b/DPPickerManager/Class/DPPickerManager.swift
@@ -14,7 +14,7 @@ public typealias DPPickerValueIndexCompletion = (_ value: String?, _ index: Int,
 
 open class DPPickerManager: NSObject, UIPickerViewDelegate, UIPickerViewDataSource {
     
-    static let shared = DPPickerManager()
+    public static let shared = DPPickerManager()
 
     private typealias PickerCompletionBlock  = (_ cancel: Bool) -> Void
 


### PR DESCRIPTION
in XCode 10, error:'shared' is inaccessible due to 'internal' protection level